### PR TITLE
Review validation

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -5,7 +5,8 @@ class ReviewsController < ApplicationController
     
     def create
         shelter = Shelter.find(params[:shelter_id])
-        shelter.reviews.create!(*review_params)
+        review = shelter.reviews.new(*review_params)
+        review.save
         redirect_to "/shelters/#{shelter.id}"
     end
 

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -6,8 +6,12 @@ class ReviewsController < ApplicationController
     def create
         shelter = Shelter.find(params[:shelter_id])
         review = shelter.reviews.new(*review_params)
-        review.save
-        redirect_to "/shelters/#{shelter.id}"
+        if review.save
+            redirect_to "/shelters/#{shelter.id}"
+        else
+            flash[:notice] = "Review not posted: You must fill in the Title, Rating, and Content in order to post a review."
+            render :new
+        end
     end
 
     private

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -10,7 +10,7 @@ class ReviewsController < ApplicationController
             redirect_to "/shelters/#{shelter.id}"
         else
             flash[:notice] = "Review not posted: You must fill in the Title, Rating, and Content in order to post a review."
-            render :new
+            redirect_to "/shelters/#{shelter.id}/reviews/new"
         end
     end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,10 +9,16 @@
   </head>
 
   <body>
+  
     <nav class="row">
       <%= link_to "Pets", "/pets", class: "col-2 nav-link" %>
       <%= link_to "Shelters", "/shelters", class: "col-2 nav-link" %>
     </nav>
+
+    <% flash.each do |type, message| %>
+      <p><%= message %></p>
+    <% end %>
+
     <%= yield %>
   </body>
 </html>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -9,7 +9,7 @@
             <%= text_field_tag :title, nil, class: "col-5" %>
 
             <%= label_tag :rating, nil, class: "col-3 light-text" %>
-            <%= select_tag :rating, options_for_select([1, 2, 3, 4, 5]) %>
+            <%= select_tag :rating, options_for_select(['', 1, 2, 3, 4, 5]) %>
         </div>
         <div class="row form-entry">    
             <%= label_tag :content, nil, class: "col-2 light-text" %>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -13,7 +13,7 @@
         </div>
         <div class="row form-entry">    
             <%= label_tag :content, nil, class: "col-2 light-text" %>
-            <%= text_field_tag :content, nil, class: "col-8" %>
+            <%= text_area_tag :content, nil, class: "col-8" %>
         </div>
         <div class="row form-entry">
             <%= label_tag :picture, nil, class: "col-2 light-text" %>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -6,14 +6,14 @@
     <%= form_tag "/shelters/#{@shelter_id}/reviews", method: :post do %>
         <div class="row form-entry">
             <%= label_tag :title, nil, class: "col-2 light-text" %>
-            <%= text_field_tag :title, nil, class: "col-5", required: true %>
+            <%= text_field_tag :title, nil, class: "col-5" %>
 
             <%= label_tag :rating, nil, class: "col-3 light-text" %>
-            <%= select_tag :rating, options_for_select([1, 2, 3, 4, 5]), required: true %>
+            <%= select_tag :rating, options_for_select([1, 2, 3, 4, 5]) %>
         </div>
         <div class="row form-entry">    
             <%= label_tag :content, nil, class: "col-2 light-text" %>
-            <%= text_field_tag :content, nil, class: "col-8", required: true %>
+            <%= text_field_tag :content, nil, class: "col-8" %>
         </div>
         <div class="row form-entry">
             <%= label_tag :picture, nil, class: "col-2 light-text" %>

--- a/spec/features/reviews/create_review_spec.rb
+++ b/spec/features/reviews/create_review_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "New review page", type: :feature do
         click_button "Submit"
 
         expect(page).to have_content("Review not posted: You must fill in the Title, Rating, and Content in order to post a review.")
-        expect(current_path).to eq("/shelters/#{shelter_1.id}/reviews/new")
+        expect(page).to have_content("New Review")
         expect(page).to have_button("Submit")
     end
 end

--- a/spec/features/reviews/create_review_spec.rb
+++ b/spec/features/reviews/create_review_spec.rb
@@ -23,4 +23,23 @@ RSpec.describe "New review page", type: :feature do
         expect(page).to have_content("5")
         expect(page).to have_content("Very clean place with happy pets.")
     end
+
+    it "will not create a review id required fields are missing" do
+        shelter_1 = Shelter.create( name: "4 Paws Rescue",
+                            address: "6567 W Long Dr.",
+                            city: "Littleton",
+                            state: "CO",
+                            zip: "80123")
+        visit "/shelters/#{shelter_1.id}"
+        click_link("Write a Review")
+        expect(current_path).to eq("/shelters/#{shelter_1.id}/reviews/new")
+
+        fill_in :title, with: "Great Shelter"
+        select('5', from: :rating)
+        click_button "Submit"
+
+        expect(page).to have_content("Review not posted: You must fill in the Title, Rating, and Content in order to post a review.")
+        expect(current_path).to eq("/shelters/#{shelter_1.id}/reviews/new")
+        expect(page).to have_button("Submit")
+    end
 end

--- a/spec/features/reviews/create_review_spec.rb
+++ b/spec/features/reviews/create_review_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe "New review page", type: :feature do
         click_button "Submit"
 
         expect(page).to have_content("Review not posted: You must fill in the Title, Rating, and Content in order to post a review.")
-        expect(page).to have_content("New Review")
-        expect(page).to have_button("Submit")
+        expect(current_path).to eq("/shelters/#{shelter_1.id}/reviews/new")
     end
 end


### PR DESCRIPTION
Adds flash message for when a review can't be posted due to missing required fields. Redirects the user to a new form and renders text letting the user know which fields are required. Along with this a new default value of blank was added to the rating dropdown so that it requires a user input to be changed to a valid value. Required fields were dropped from the form HTML as the required fields are now being handled by the flash message.