### PR TITLE
Stories 31 32

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -38,8 +38,15 @@ class PetsController < ApplicationController
     end
 
     def destroy
-        Pet.destroy(params[:id])
-        redirect_to "/pets"
+        pet = Pet.find(params[:id])
+        if pet.pet_applications.any? {|application| application.approved }
+            flash[:notice] = "This pet cannot be deleted due to approved applications"
+            redirect_to request.referrer
+        else
+            pet.pet_applications.each {|pet_app| PetApplication.destroy(pet_app.id) }
+            Pet.destroy(pet.id)
+            redirect_to "/pets"
+        end
     end
 
 

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -45,6 +45,7 @@ class PetsController < ApplicationController
         else
             pet.pet_applications.each {|pet_app| PetApplication.destroy(pet_app.id) }
             Pet.destroy(pet.id)
+            favorites.remove_pet(pet.id)
             redirect_to "/pets"
         end
     end

--- a/spec/features/pets/delete_spec.rb
+++ b/spec/features/pets/delete_spec.rb
@@ -80,4 +80,62 @@ RSpec.describe "When I visit the pet show page and click delete", type: :feature
         expect(current_path).to eq("/pets")
         expect(page).to have_content("This pet cannot be deleted due to approved applications")
     end
+
+    it "removes a pet from favorites when it is deleted" do
+        shelter_1 = Shelter.create( name:    "4 Paws Rescue",
+                                    address: "6567 W Long Dr.",
+                                    city:    "Littleton",
+                                    state:   "CO",
+                                    zip:     "80123")
+
+
+        pet_1 = Pet.create( name:    "Teddy",
+                                    image: "https://i.pinimg.com/originals/47/4e/7d/474e7d2479512428a1a4716d5d1656eb.jpg",
+                                    age:    "10",
+                                    sex:   "M",
+                                    description: "A sweet dog looking for a loving home",
+                                    shelter_id: shelter_1.id,
+                                    adoption_status: "Adoptable")
+
+        application1 = Application.create({    
+                name: "Hambone Fakenamington",
+                address: "555 s. Sunset st.",
+                city: "Los Angeles",
+                state: "CA",
+                zip: 55555,
+                phone_number: 3459999,
+                description: "I want the pet"
+                })
+        PetApplication.create(pet_id: pet_1.id, application_id: application1.id)
+
+        application2 = Application.create({    
+                name: "Coffee Maker",
+                address: "555 s. Sunset st.",
+                city: "Los Angeles",
+                state: "CA",
+                zip: 55555,
+                phone_number: 3459999,
+                description: "I want the pet"
+                })
+        PetApplication.create(pet_id: pet_1.id, application_id: application2.id)
+
+
+        visit "/pets/#{pet_1.id}"
+        click_link "Favorite"
+        within("nav") do
+            expect(page).to have_content("Favorites: 1")
+        end
+        
+        click_link "Delete Pet"
+        
+        expect(current_path).to eq("/pets")
+        expect(page).to_not have_content("Teddy")
+        expect(page).to_not have_content("10")
+        expect(page).to_not have_content("M")
+        expect(page).to_not have_css("img[src*='https://i.pinimg.com/originals/47/4e/7d/474e7d2479512428a1a4716d5d1656eb.jpg']")
+
+        within("nav") do
+            expect(page).to have_content("Favorites: 0")
+        end
+    end
 end

--- a/spec/features/pets/delete_spec.rb
+++ b/spec/features/pets/delete_spec.rb
@@ -33,4 +33,51 @@ RSpec.describe "When I visit the pet show page and click delete", type: :feature
         expect(page).to_not have_content("M")
         expect(page).to_not have_css("img[src*='https://i.pinimg.com/originals/47/4e/7d/474e7d2479512428a1a4716d5d1656eb.jpg']")
     end
+
+    it "can't delete a pet with approved applications" do
+        shelter_1 = Shelter.create( name:    "4 Paws Rescue",
+                                    address: "6567 W Long Dr.",
+                                    city:    "Littleton",
+                                    state:   "CO",
+                                    zip:     "80123")
+
+
+        pet_1 = Pet.create( name:    "Teddy",
+                                    image: "https://i.pinimg.com/originals/47/4e/7d/474e7d2479512428a1a4716d5d1656eb.jpg",
+                                    age:    "10",
+                                    sex:   "M",
+                                    description: "A sweet dog looking for a loving home",
+                                    shelter_id: shelter_1.id,
+                                    adoption_status: "Adoptable")
+
+        application1 = Application.create({    
+                name: "Hambone Fakenamington",
+                address: "555 s. Sunset st.",
+                city: "Los Angeles",
+                state: "CA",
+                zip: 55555,
+                phone_number: 3459999,
+                description: "I want the pet"
+                })
+        PetApplication.create(pet_id: pet_1.id, application_id: application1.id)
+
+
+        visit "/applications/#{application1.id}"
+        click_link "Approve"
+        expect(current_path).to eq("/pets/#{pet_1.id}")
+
+        expect(page).to have_content("Adoption status: Pending")
+        expect(page).to have_content("On hold for Hambone Fakenamington")
+        
+        click_link "Delete Pet"
+        
+        expect(current_path).to eq("/pets/#{pet_1.id}")
+        expect(page).to have_content("This pet cannot be deleted due to approved applications")
+
+        visit("/pets")
+        click_link "Delete"
+        
+        expect(current_path).to eq("/pets")
+        expect(page).to have_content("This pet cannot be deleted due to approved applications")
+    end
 end


### PR DESCRIPTION
Functionality added to make it so pets cannot be deleted if they have any approved applications. If a user clicks delete on a pet with approved applications it gets a flash message telling them it cannot be deleted due to approved applications. If a pet has applications that are not approved and a user clicks to delete the pet, all PetApplications tied to this pet are deleted as well. If a user deletes a pet that is in favorites, the pet is removed from favorites.